### PR TITLE
Enhance squadron formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ $faker->vehicle;    // Millennium Falcon
 
 ### `HydrefLab\JediFaker\Provider\Squadron`
 ```
-$faker->pilot;      // Red Leader
-$faker->squadron;   // Blue Squadron
-$faker->rank;       // Pilot
+$faker->squadron;       // Green
+$faker->squadronName;   // Blue Squadron
+$faker->pilot;          // Red Leader or Blue #7
+$faker->pilotRank;      // Pilot
 ```
 
 ## Contributing

--- a/src/Provider/Squadron.php
+++ b/src/Provider/Squadron.php
@@ -10,7 +10,7 @@ class Squadron extends Base
      * @var array
      */
     protected static $pilotFormat = [
-        '{{squadron}} {{rank}}'
+        '{{squadron}} {{pilotRank}}'
     ];
 
     /**
@@ -39,40 +39,51 @@ class Squadron extends Base
     /**
      * @var array
      */
-    protected static $rank = [
+    protected static $pilotRank = [
         'Leader', 'Pilot',
     ];
 
     /**
      * @return string
      */
-    public function pilot(): string
-    {
-        // Replace generated 'Pilot' word with '~#' in order to use numerify function,
-        // then replace '~' with '#' to have results such as 'Gold #7'.
-
-        $pilot = str_replace('Pilot', '~#', $this->generator->parse(static::randomElement(static::$pilotFormat)));
-
-        return str_replace('~', '#', static::numerify($pilot));
-    }
-
-    /**
-     * @return string
-     */
     public function squadron(): string
     {
-        return sprintf(
-            '%s %s',
-            $this->generator->parse(static::randomElement(static::$squadron)),
-            static::$squadronWord
-        );
+        return $this->generator->parse(static::randomElement(static::$squadron));
     }
 
     /**
      * @return string
      */
-    public function rank(): string
+    public function squadronName(): string
     {
-        return $this->generator->parse(static::randomElement(static::$rank));
+        return $this->generator->parse(static::randomElement(static::squadronFormat()));
+    }
+
+    /**
+     * @return string
+     */
+    public function pilot(): string
+    {
+        $pilot = $this->generator->parse(static::randomElement(static::$pilotFormat));
+
+        return false !== strpos($pilot, 'Pilot')
+            ? str_replace('Pilot', '#' . static::numberBetween(1, 12), $pilot)
+            : $pilot;
+    }
+
+    /**
+     * @return string
+     */
+    public function pilotRank(): string
+    {
+        return $this->generator->parse(static::randomElement(static::$pilotRank));
+    }
+
+    /**
+     * @return array
+     */
+    protected static function squadronFormat(): array
+    {
+        return ['{{squadron}} ' . static::$squadronWord];
     }
 }

--- a/src/Provider/Squadron.php
+++ b/src/Provider/Squadron.php
@@ -40,7 +40,7 @@ class Squadron extends Base
      * @var array
      */
     protected static $pilotRank = [
-        'Leader', 'Pilot',
+        'Leader', 'Pilot', 'Pilot', 'Pilot', 'Pilot', 'Pilot', 'Pilot', 'Pilot', 'Pilot', 'Pilot',
     ];
 
     /**

--- a/tests/Provider/SquadronTest.php
+++ b/tests/Provider/SquadronTest.php
@@ -13,6 +13,18 @@ class SquadronTest extends TestCase
         $this->assertNotNull($faker->squadron);
     }
 
+    public function testSquadronNameContainsSquadronWord()
+    {
+        $faker = Factory::create();
+        $this->assertContains('Squadron', $faker->squadronName);
+    }
+
+    public function testSquadronDoesNotContainSquadronWord()
+    {
+        $faker = Factory::create();
+        $this->assertNotContains('Squadron', $faker->squadron);
+    }
+
     public function testPilotIsNotNull()
     {
         $faker = Factory::create();
@@ -22,6 +34,6 @@ class SquadronTest extends TestCase
     public function testRankIsNotNull()
     {
         $faker = Factory::create();
-        $this->assertNotNull($faker->rank);
+        $this->assertNotNull($faker->pilotRank);
     }
 }


### PR DESCRIPTION
* add `squadronName` method that outputs for example `Gold Squadron` (previously `squadron` method)
* update `squadron` method to return squadron 'main' name (Gold, Red, etc.)
* update `pilot` method to return pilot number from 1 to 12 (in case of a pilot)
* rename `rank` method to `pilotRank`
* lower the probability of generating squadron leader